### PR TITLE
clenup

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,31 +1,4 @@
 ---
-# defaults file for jffz.netdata
-debian:
-  packages:
-    - autoconf
-    - autoconf-archive
-    - autogen
-    - automake
-    - gcc
-    - git
-    - libmnl-dev
-    - make
-    - pkg-config
-    - uuid-dev
-    - zlib1g-dev
-
-rhel:
-  packages:
-    - autoconf
-    - autoconf-archive
-    - autogen
-    - automake
-    - curl
-    - gcc
-    - git
-    - jq
-    - libmnl-devel
-    - libuuid-devel
-    - make
-    - pkgconfig
-    - zlib-devel
+# netdata_registry: "http://your-registry-server.comp.tld:19999"
+netdata_registry: ""
+netdata_notifications: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,33 +1,28 @@
 ---
-# tasks file for jffz.netdata
+- name: Gather variables for each operating system
+  include_vars: "{{ item }}"
+  with_items: "{{ ansible_os_family | lower }}.yml"
+  tags:
+    - always
+
 - name: update the apt cache
-  apt: >
-        update_cache=yes
-        cache_valid_time=86400
-  when: ansible_os_family == "Debian"
-  
-- name: "Install pre-requisites"    
   apt:
-    name: "{{ item }}"
-    state: present
-  with_items: 
-    "{{ debian.packages }}"
-  when: ansible_os_family == "Debian"
-  
+    update_cache: yes
+    cache_valid_time: 86400
+  when: ansible_os_family == "Debian"  
+ 
 - name: "EPEL repo"
-  yum:
+  package:
     name: epel-release
     state: present
   when: ansible_os_family == "RedHat"
 
-- name: "Install pre-requisites"    
-  yum:
+- name: "Install pre-requisites"
+  package:
     name: "{{ item }}"
     state: present
-  with_items: 
-    "{{ rhel.packages }}"
-  when: ansible_os_family == "RedHat"
-
+  with_items: "{{ netdata_dependencies }}"
+ 
 #Clone reopo into source and keep it for later (upgrade)
 - name: "Clone repo"
   git:
@@ -42,27 +37,26 @@
   notify:  Restart netdata
   when: gitupdate.changed
 
-
 # we keep the sources for upgrades
 #- name: "Clean git repo"
 #  file:
 #    path: /usr/src/netdata
 #    state: absent
 
-
-#Optional: use your own registry
-- lineinfile:
+- name: use custom registry
+  lineinfile:
     dest: /etc/netdata/netdata.conf
     regexp: '^\t# registry to announce.*'
-    line: '\t registry to announce = http://your-registry-server.comp.tld:19999'
+    line: '\t registry to announce = {{ netdata_registry }}'
     backrefs: yes
+  when: netdata_registry != ""
 
-#Optional: Disable notifications
-- lineinfile:
+- name: Disable notifications
+  lineinfile:
     dest: /etc/netdata/health_alarm_notify.conf
     regexp: '^SEND_EMAIL="YES"'
     line: 'SEND_EMAIL="NO"'
     backrefs: yes
-
+  when: not netdata_notifications
 
 #ToDo Uninstaller -  see netdata-uninstaller.sh

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,0 +1,12 @@
+netdata_dependencies:
+ - autoconf
+ - autoconf-archive
+ - autogen
+ - automake
+ - gcc
+ - git
+ - libmnl-dev
+ - make
+ - pkg-config
+ - uuid-dev
+ - zlib1g-dev

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,0 +1,14 @@
+netdata_dependencies:
+  - autoconf
+  - autoconf-archive
+  - autogen
+  - automake
+  - curl
+  - gcc
+  - git
+  - jq
+  - libmnl-devel
+  - libuuid-devel
+  - make
+  - pkgconfig
+  - zlib-devel


### PR DESCRIPTION
- cleaner installation (using `package` module)
- better package mgmt - use `include_vars` with os family autodetection
- optional tasks are really optional