### PR TITLE
Use "force: true" when cloning the repo to avoid failures

### DIFF
--- a/tasks/install_script.yml
+++ b/tasks/install_script.yml
@@ -16,6 +16,7 @@
     repo: https://github.com/firehol/netdata.git
     dest: /usr/src/netdata
     version: master
+    force: true
   register: __gitupdate
   until: __gitupdate is succeeded
   retries: 5


### PR DESCRIPTION
I've been using `jffz.netdata` for a while, but it began to fail on some of my servers recently with this message:

```
fatal: [some-server]: FAILED! => {"attempts": 5, "before":
"19d197d22bd6058cded8aa604fd17272bf046881", "changed": false,
"msg": "Local modifications exist in repository (force=no)."}
```

Going to `/usr/src/netdata` and checking git status revealed that the working copy got dirty for some reason (I'm not really sure why). This was preventing `git pull` from being successful.

<img width="617" alt="screenshot 2018-12-03 at 08 42 55" src="https://user-images.githubusercontent.com/608862/49363228-02327f00-f6d9-11e8-9d69-3348763b3d6c.png">

Adding `force: true` to the clone/update task was enough to recover from the problem. Netdata updates successfully again 🎉